### PR TITLE
docs(installations): use correct tar filename

### DIFF
--- a/lang/en/docs/_installations/tarball.md
+++ b/lang/en/docs/_installations/tarball.md
@@ -51,7 +51,7 @@ tar zvxf latest.tar.gz
 ```sh
 cd /opt
 wget https://yarnpkg.com/latest-rc.tar.gz
-tar zvxf latest.tar.gz
+tar zvxf latest-rc.tar.gz
 # Yarn is now in /opt/yarn-[version]/
 ```
 </div>


### PR DESCRIPTION
Right now, the tar snippet will fail because the file is called `latest-rc.tar.gz` and not `latest.tar.gz`